### PR TITLE
fix(useDidUnmount): call effect with updated dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,10 +112,13 @@ Executes an effect when the component unmounts. The effect may also be asynchron
 
 ```ts
 useDidUnmount(async () => {
-  await busyWork();
+  await busyWork(someState);
   console.log('heading out');
-});
+}, [someState]);
 ```
+
+Any dependencies used inside the effect must be declared, however, the effect is not called when the
+dependencies change. The effect is only called when the component is being unmounted.
 
 ### Use Lazy Ref
 

--- a/src/__tests__/useDidUnmount.ts
+++ b/src/__tests__/useDidUnmount.ts
@@ -7,33 +7,35 @@ let hook: any;
 
 beforeEach(() => {
   cleanup = jest.fn();
-  hook = useDidUnmount.bind(null, cleanup);
+  hook = ({ func = cleanup, deps }: any = {}) => {
+    useDidUnmount(func, deps);
+  };
 });
 
 it('does not call the effect if the component is mounted', () => {
   renderHook(hook);
 
-  expect(cleanup.mock.calls.length).toEqual(0);
+  expect(cleanup).not.toHaveBeenCalled();
 });
 
 it('calls the effect when the component gets unmounted', () => {
   const { unmount } = renderHook(hook);
 
-  expect(cleanup.mock.calls.length).toEqual(0);
+  expect(cleanup).not.toHaveBeenCalled();
   unmount();
 
-  expect(cleanup.mock.calls.length).toEqual(1);
+  expect(cleanup).toHaveBeenCalledTimes(1);
 });
 
 it('calls the effect only once', () => {
   const { unmount } = renderHook(hook);
 
-  expect(cleanup.mock.calls.length).toEqual(0);
+  expect(cleanup).not.toHaveBeenCalled();
   unmount();
   unmount();
   unmount();
 
-  expect(cleanup.mock.calls.length).toEqual(1);
+  expect(cleanup).toHaveBeenCalledTimes(1);
 });
 
 it('runs an async funciton', async () => {
@@ -52,10 +54,38 @@ it('runs an async funciton', async () => {
 
   unmount();
 
-  expect(cleanup.mock.calls.length).toEqual(1);
+  expect(cleanup).toHaveBeenCalledTimes(1);
   expect(finished).toBe(false);
 
   resolve!();
 
   expect(finished).toBe(false);
+});
+
+it('calls the effect with updated dependencies', () => {
+  const secondCleanup = jest.fn();
+  const { unmount, rerender } = renderHook(hook, {
+    initialProps: { func: cleanup, deps: [cleanup] },
+  });
+
+  // updating dependencies
+  rerender({ func: secondCleanup, deps: [secondCleanup] });
+  unmount();
+
+  expect(cleanup).not.toHaveBeenCalled();
+  expect(secondCleanup).toHaveBeenCalledTimes(1);
+});
+
+it('does not update the effect when the dependencies have not been updated', () => {
+  const secondCleanup = jest.fn();
+  const { unmount, rerender } = renderHook(hook, {
+    initialProps: { func: cleanup, deps: [cleanup] },
+  });
+
+  // sending a new cleanup func, but keeping the same dependencies
+  rerender({ func: secondCleanup, deps: [cleanup] });
+  unmount();
+
+  expect(cleanup).toHaveBeenCalledTimes(1);
+  expect(secondCleanup).not.toHaveBeenCalled();
 });

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -134,14 +134,32 @@ export const useDidMount = (
 /**
  * Runs an effect when the component gets unmounted
  *
+ * Any dependencies used inside the effect must be passed as argument, however, the effect is not
+ * called when the dependencies change. The effect is only called when the component is being
+ * unmounted.
+ *
  * @param effect the effect to be executed. May be asynchronous
+ * @param dependencies The effect's dependencies.
  */
-export const useDidUnmount = (effect: () => void | Promise<void>) => {
+export const useDidUnmount = <Dependencies extends readonly any[]>(
+  effect: () => void | Promise<void>,
+  dependencies?: Dependencies,
+) => {
+  const unmounting = useRef(false);
   useEffect(
     () => () => {
-      effect();
+      unmounting.current = true;
     },
     [],
+  );
+
+  useEffect(
+    () => () => {
+      if (unmounting.current) {
+        effect();
+      }
+    },
+    dependencies || [],
   );
 };
 


### PR DESCRIPTION
Now, when the effect is called, it will have updated dependencies, if they have been passed.

fix #8