### PR TITLE
Fix: useWorkerLoad and useLazyRef

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,27 +92,19 @@ const { isLoading, error, result, callback } = useWorker(
 `isLoading` is set to true as soon as the callback is loaded and only returns to `false` when it
 ends or when an error happens. If an exception is thrown or a promise fails, `error` will be updated.
 
-### Worker Load
+### Worker State
 
 This is a worker that starts loading immediately and stores the result in a state. Useful for
 loading data when you render a component:
 
 ```ts
-const { isLoading, error, data } = useWorkerLoad(
+const { isLoading, error, data, callback } = useWorkerState(
   async () => {
-    return await getUserName();
+    return await getUserName(userId);
   },
+  [userId],
   'no-name', // data's initial value
 );
-```
-
-If the worker fails, the error is returned in the `error` state with a retry function:
-
-```ts
-const { error } = useWorkerLoad(...);
-
-error?.value // the actual Error object
-error?.retry() // calls the worker again
 ```
 
 ### Did Mount

--- a/src/__tests__/useLazyRef.ts
+++ b/src/__tests__/useLazyRef.ts
@@ -13,6 +13,17 @@ it('calls factory on first call', () => {
   expect(callbackFn.mock.calls.length).toEqual(1);
 });
 
+it('does not call factory when value is unset', () => {
+  const { result, rerender } = renderHook(mockHook);
+  expect(callbackFn.mock.calls.length).toEqual(1);
+
+  // act
+  result.current.current = undefined;
+  rerender();
+
+  expect(callbackFn.mock.calls.length).toEqual(1);
+});
+
 describe('change in current value', () => {
   const assertChangeCurrentValue = () => {
     // initial value

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -8,38 +8,28 @@ import {
 } from 'react';
 
 /**
- * The return of a [[useWorkerLoad]] call.
- *
- * See [[RetryWorkerError]] for errors.
+ * The return of a [[useWorkerState]] call.
  *
  * @typeparam Data The worker's return type
  */
-interface WorkerLoad<Data> {
+export interface WorkerLoad<Data> {
   /** Indicates if the worker is running */
   isLoading: boolean;
 
   /** The worker's returned value stored in a state */
   data: Data;
 
-  /** An optional object that contains any thrown errors, if any, and a retry function */
-  error?: RetryWorkerError;
+  /** The error thrown by the worker's call */
+  error?: Error;
 
   /** Sets [[isLoading]] state manually */
   setIsLoading: (_: boolean) => void;
 
   /** Sets [[error]] state manually */
   setError: (_: Error | undefined) => void;
-}
-
-/**
- * Encapsulates [[useWorkerLoad]]'s errors and retry function
- */
-interface RetryWorkerError {
-  /** The error thrown by the worker's call */
-  value: Error;
 
   /** Calls the worker again */
-  retry: () => Promise<void>;
+  callback: () => Promise<void>;
 }
 
 /**
@@ -515,11 +505,13 @@ export const useLazyRef = <T extends any>(
  * See [[useWorker]] for more details.
  *
  * @param worker An asynchronous function that returns data, which is saved into a state
+ * @param dependencies The callback dependencies.
  * @typeparam Data The worker's return type
  * @category Workers
  */
-export function useWorkerLoad<Data>(
+export function useWorkerState<Data>(
   worker: () => Promise<Data | undefined>,
+  dependencies: readonly any[],
 ): WorkerLoad<Data | undefined>;
 
 /**
@@ -528,41 +520,39 @@ export function useWorkerLoad<Data>(
  * See [[useWorker]] for more details.
  *
  * @param worker An asynchronous function that returns data, which is saved into a state
+ * @param dependencies The callback dependencies.
  * @param initialValue The data's initial value
  * @typeparam Data The worker's return type
  * @category Workers
  */
-export function useWorkerLoad<Data>(
+export function useWorkerState<Data>(
   worker: () => Promise<Data>,
+  dependencies: readonly any[],
   initialValue: Data,
 ): WorkerLoad<Data>;
 
-export function useWorkerLoad<Data>(
+export function useWorkerState<Data>(
   worker: () => Promise<typeof initialValue>,
+  dependencies: readonly any[],
   initialValue?: Data,
 ): WorkerLoad<typeof initialValue> {
   const [data, setData] = useState<typeof initialValue>(initialValue);
-  const {
-    isLoading,
-    error,
-    setError,
-    setIsLoading,
-    callback,
-  } = useWorker(async () => {
-    setData(await worker());
-  }, []);
+  const { isLoading, error, setError, setIsLoading, callback } = useWorker(
+    async () => {
+      setData(await worker());
+    },
+    dependencies,
+  );
 
   // start loading immediately
   useDidMount(callback);
 
   return {
+    callback,
     data,
     isLoading,
     setIsLoading,
     setError,
-    error: error && {
-      value: error,
-      retry: callback,
-    },
+    error,
   };
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -490,10 +490,12 @@ export const useDidUnmount = (
 export const useLazyRef = <T extends any>(
   factory: () => T,
 ): MutableRefObject<T> => {
+  const didInit = useRef(false);
   const ref = useRef<T | undefined>(undefined);
 
-  if (ref.current === void 0 || ref.current === null) {
+  if (!didInit.current) {
     ref.current = factory();
+    didInit.current = true;
   }
 
   return ref as MutableRefObject<T>;


### PR DESCRIPTION
- `useWorkerLoad` now always exposes the callback function, even when there are no errors.
- `useLazyRef` was calling the factory function more than once if the ref's `current` value was set to `undefined` or `null`.