### PR TITLE
Feat: useWorkerState with factory function

### DIFF
--- a/scripts/deploy-docs-folder.sh
+++ b/scripts/deploy-docs-folder.sh
@@ -6,8 +6,8 @@ git worktree add docs origin/gh-pages && \
     yarn docs && \
     cd docs && \
     git add -f . && \
-    git config --global user.email "actions@github.com" && \
-    git config --global user.name "Github Actions" && \
+    git config user.email "actions@github.com" && \
+    git config user.name "Github Actions" && \
     git commit -m "Deploying docs ${GITHUB_SHA}" --quiet --no-verify && \
     git push "$REPO_PATH" HEAD:gh-pages
 

--- a/src/__tests__/useWorkerState.ts
+++ b/src/__tests__/useWorkerState.ts
@@ -73,6 +73,25 @@ describe('initial values', () => {
 
     expect(data).toBe(initialValue);
   });
+
+  it('may be passed as a factory', async () => {
+    const initialValue = 'foobar';
+    const {
+      result: {
+        current: { data },
+      },
+      waitForNextUpdate,
+    } = renderHook(useHookHelper, {
+      initialProps: {
+        ...initialProps,
+        initialValue: () => initialValue,
+      },
+    });
+
+    await waitForNextUpdate();
+
+    expect(data).toBe(initialValue);
+  });
 });
 
 it('stops loading when effect resolves', async () => {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -554,20 +554,20 @@ export function useWorkerState<Data>(
  *
  * @param worker An asynchronous function that returns data, which is saved into a state
  * @param dependencies The callback dependencies.
- * @param initialValue The data's initial value
+ * @param initialValue The data's initial value. May be a factory function.
  * @typeparam Data The worker's return type
  * @category Workers
  */
 export function useWorkerState<Data>(
   worker: () => Promise<Data>,
   dependencies: readonly any[],
-  initialValue: Data,
+  initialValue: Data | (() => Data),
 ): WorkerLoad<Data>;
 
 export function useWorkerState<Data>(
   worker: () => Promise<typeof initialValue>,
   dependencies: readonly any[],
-  initialValue?: Data,
+  initialValue?: Data | (() => Data),
 ): WorkerLoad<typeof initialValue> {
   const [data, setData] = useState<typeof initialValue>(initialValue);
   const { isLoading, error, setError, setIsLoading, callback } = useWorker(


### PR DESCRIPTION
Like `useState`, the hook now can receive a factory function to create the state's initial value.
